### PR TITLE
Update version nos

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ There are a few separate packages you need to install:
 
 ```yaml
 dependencies:
-  functional_widget_annotation: 0.1.0
+  functional_widget_annotation: ^0.3.0
 
 dev_dependencies:
-  functional_widget: 0.2.2
-  build_runner: 1.1.2
+  functional_widget: ^0.4.0
+  build_runner: ^1.1.2
 ```
 
 


### PR DESCRIPTION
The version numbers were outdated:

```
flutter packages get
Running "flutter packages get" in sample_app...               
Because SampleApp depends on functional_widget 0.2.2 which doesn't match any versions, version solving failed.
```
Fixed and updated to latest version.