### PR TITLE
Params with unknown types can have attributes

### DIFF
--- a/functional_widget/lib/findBeginToken.dart
+++ b/functional_widget/lib/findBeginToken.dart
@@ -7,5 +7,10 @@ Token findBeginToken(ParameterElement element) {
       element.session.getParsedLibraryByElement(element.library);
   final declaration = parsedLibrary.getElementDeclaration(element);
   final parameter = declaration.node as FormalParameter;
-  return parameter.beginToken;
+  if (parameter is DefaultFormalParameter &&
+      parameter.parameter is SimpleFormalParameter) {
+    return (parameter.parameter as SimpleFormalParameter).type.beginToken;
+  } else {
+    return parameter.beginToken;
+  }
 }

--- a/functional_widget/test/src/success.dart
+++ b/functional_widget/test/src/success.dart
@@ -70,6 +70,10 @@ Widget annotated({@meta.required int foo}) => Container();
 // ignore: undefined_class
 Widget undefinedType({Color foo}) => Container();
 
+@widget
+// ignore: undefined_class
+Widget annotatedUndefinedType({@meta.required Color foo}) => Container();
+
 @hwidget
 Widget hookExample() => Container();
 

--- a/functional_widget/test/success_test.dart
+++ b/functional_widget/test/success_test.dart
@@ -180,6 +180,18 @@ class UndefinedType extends StatelessWidget {
 }
 '''));
     });
+    test('annotated undefined type', () async {
+      await _expect('annotatedUndefinedType', completion('''
+class AnnotatedUndefinedType extends StatelessWidget {
+  const AnnotatedUndefinedType({Key key, @required this.foo}) : super(key: key);
+
+  final Color foo;
+
+  @override
+  Widget build(BuildContext _context) => annotatedUndefinedType(foo: foo);
+}
+'''));
+    });
     test('hook widget', () async {
       await _expect('hookExample', completion('''
 class HookExample extends HookWidget {


### PR DESCRIPTION
Currently, unknown types (such as Color) break when attributes are used (such as @required). This change causes the correct token to be used in the case of an unknown type with attributes.