### PR TITLE
Upgrade analyzer 0.37.0

### DIFF
--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'
     build: '>=1.1.2 <2.0.0'
-    analyzer: '>=0.35.4 <=0.36.3'
+    analyzer: '>=0.35.4 <0.37.0'
     meta: ^1.1.6
 
 dev_dependencies:

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'
     build: '>=1.1.2 <2.0.0'
-    analyzer: '>=0.35.4 <0.36.0'
+    analyzer: '>=0.35.4 <=0.36.3'
     meta: ^1.1.6
 
 dev_dependencies:


### PR DESCRIPTION
Allow the version 0.36.3 parser to ensure compatibility with mobx_codegen.
