### PR TITLE
Option remove leading underscore

### DIFF
--- a/functional_widget/CHANGELOG.md
+++ b/functional_widget/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- added option `removeLeadingUnderscore`
+
 ## 0.7.0
 
 - support `@required` for `Color` and other `dart:ui` types

--- a/functional_widget/README.md
+++ b/functional_widget/README.md
@@ -135,6 +135,7 @@ targets:
           debugFillProperties: false
           widgetType: stateless # or 'hook'
           equality: none # or 'identical'/'equal'
+          removeLeadingUnderscore: false
 ```
 
 `FunctionalWidget` decorator will override the default behavior for one specific widget.
@@ -275,6 +276,31 @@ or using `@FunctionalWidget` decorator:
 ```dart
 @FunctionalWidget(equality: FunctionalWidgetEquality.identical)
 Widget example(int foo, String bar) => Container();
+```
+
+### Making public widgets from private functions
+
+Quite often, you don't want to export the function itself, but only the generated widget so that users do not accidently use the function. For this, we have the option `removeLeadingUnderscore` to remove the first leading underscore (if any) of the function name when creating the class name.
+
+For example, with the option turned on, a function `_foo` would be translated to a class `Foo`. However `bar` (no leading underscore) would still be `Bar`.
+
+This option can be enabled through `build.yaml`:
+
+```yaml
+# build.yaml
+targets:
+  $default:
+    builders:
+      functional_widget:
+        options:
+          removeLeadingUnderscore: true
+```
+
+or using `@FunctionalWidget` decorator:
+
+```dart
+@FunctionalWidget(removeLeadingUnderscore: true)
+Widget _example(int foo, String bar) => Container();
 ```
 
 ### All the potential function prototypes

--- a/functional_widget/example/pubspec.lock
+++ b/functional_widget/example/pubspec.lock
@@ -19,7 +19,7 @@ packages:
       name: functional_widget_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   meta:
     dependency: transitive
     description:

--- a/functional_widget/example/pubspec.yaml
+++ b/functional_widget/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  functional_widget_annotation: ^0.5.0
+  functional_widget_annotation: ^0.5.2
 
 builders:
   functional_widget: ^0.6.0

--- a/functional_widget/example/pubspec.yaml
+++ b/functional_widget/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  functional_widget_annotation: ^0.5.2
+  functional_widget_annotation: ^0.5.1
 
 builders:
   functional_widget: ^0.6.0

--- a/functional_widget/lib/function_to_widget_class.dart
+++ b/functional_widget/lib/function_to_widget_class.dart
@@ -39,7 +39,8 @@ class FunctionalWidgetGenerator
             debugFillProperties: options?.debugFillProperties ?? false,
             equality: options?.equality ?? FunctionalWidgetEquality.none,
             widgetType: options?.widgetType ?? FunctionalWidgetType.stateless,
-            removeLeadingUnderscore: options?.removeLeadingUnderscore ?? false);
+          removeLeadingUnderscore: options?.removeLeadingUnderscore ?? false,
+        );
 
   final FunctionalWidget _defaultOptions;
   final _emitter = DartEmitter();

--- a/functional_widget/lib/function_to_widget_class.dart
+++ b/functional_widget/lib/function_to_widget_class.dart
@@ -1,4 +1,4 @@
-timport 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:functional_widget/findBeginToken.dart';
@@ -36,9 +36,9 @@ class FunctionalWidgetGenerator
     extends GeneratorForAnnotation<FunctionalWidget> {
   FunctionalWidgetGenerator([FunctionalWidget options])
       : _defaultOptions = FunctionalWidget(
-            debugFillProperties: options?.debugFillProperties ?? false,
-            equality: options?.equality ?? FunctionalWidgetEquality.none,
-            widgetType: options?.widgetType ?? FunctionalWidgetType.stateless,
+          debugFillProperties: options?.debugFillProperties ?? false,
+          equality: options?.equality ?? FunctionalWidgetEquality.none,
+          widgetType: options?.widgetType ?? FunctionalWidgetType.stateless,
           removeLeadingUnderscore: options?.removeLeadingUnderscore ?? false,
         );
 

--- a/functional_widget/lib/function_to_widget_class.dart
+++ b/functional_widget/lib/function_to_widget_class.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/element/element.dart';
+timport 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:functional_widget/findBeginToken.dart';
@@ -24,16 +24,6 @@ String _toTitle(String string, bool removeLeadingUnderscore) {
       ? title.substring(1)
       : title;
 }
-
-String _toPublic(String string, bool removeLeadingUnderscore) {
-  final title = string.replaceFirstMapped(RegExp('[a-zA-Z]'), (match) {
-    return match.group(0).toUpperCase();
-  });
-  return title.startsWith('_') && removeLeadingUnderscore
-      ? title.substring(1)
-      : title;
-}
-
 
 const _kOverrideDecorator = CodeExpression(Code('override'));
 

--- a/functional_widget/lib/function_to_widget_class.dart
+++ b/functional_widget/lib/function_to_widget_class.dart
@@ -25,6 +25,16 @@ String _toTitle(String string, bool removeLeadingUnderscore) {
       : title;
 }
 
+String _toPublic(String string, bool removeLeadingUnderscore) {
+  final title = string.replaceFirstMapped(RegExp('[a-zA-Z]'), (match) {
+    return match.group(0).toUpperCase();
+  });
+  return title.startsWith('_') && removeLeadingUnderscore
+      ? title.substring(1)
+      : title;
+}
+
+
 const _kOverrideDecorator = CodeExpression(Code('override'));
 
 /// A generator that outputs widgets from a function

--- a/functional_widget/lib/src/utils.dart
+++ b/functional_widget/lib/src/utils.dart
@@ -3,7 +3,12 @@ import 'package:build/build.dart';
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
-const _kKnownOptionsName = ['widgetType', 'equality', 'debugFillProperties'];
+const _kKnownOptionsName = [
+  'widgetType',
+  'equality',
+  'debugFillProperties',
+  'removeLeadingUnderscore'
+];
 
 FunctionalWidget parseBuilderOptions(BuilderOptions options) {
   final unknownOption = options?.config?.keys?.firstWhere(
@@ -18,11 +23,14 @@ FunctionalWidget parseBuilderOptions(BuilderOptions options) {
   final debugFillProperties =
       _parseDebugFillProperties(options.config['debugFillProperties']);
   final equality = _parseEquality(options.config['equality']);
+  final removeLeadingUnderscore =
+      _parseRemoveLeadingUnderscore(options.config['removeLeadingUnderscore']);
+
   return FunctionalWidget(
-    widgetType: widgetType,
-    debugFillProperties: debugFillProperties,
-    equality: equality,
-  );
+      widgetType: widgetType,
+      debugFillProperties: debugFillProperties,
+      equality: equality,
+      removeLeadingUnderscore: removeLeadingUnderscore);
 }
 
 bool _parseDebugFillProperties(dynamic value) {
@@ -71,13 +79,26 @@ FunctionalWidgetType _parseWidgetType(dynamic value) {
       'Invalid value. Potential values are `hook` or `stateless`');
 }
 
+bool _parseRemoveLeadingUnderscore(dynamic value) {
+  if (value == null) {
+    // ignore: avoid_returning_null
+    return null;
+  }
+  if (value is bool) {
+    return value;
+  }
+  throw ArgumentError.value(value, 'removeLeadingUnderscore',
+      'Invalid value. Potential values are `true` or `false`');
+}
+
 FunctionalWidget parseFunctionalWidetAnnotation(ConstantReader reader) {
   return FunctionalWidget(
-    widgetType:
-        _parseEnum(reader.read('widgetType'), FunctionalWidgetType.values),
-    equality:
-        _parseEnum(reader.read('equality'), FunctionalWidgetEquality.values),
-  );
+      widgetType:
+          _parseEnum(reader.read('widgetType'), FunctionalWidgetType.values),
+      equality:
+          _parseEnum(reader.read('equality'), FunctionalWidgetEquality.values),
+      removeLeadingUnderscore:
+          _parseBool(reader.read('removeLeadingUnderscore')));
 }
 
 T _parseEnum<T>(ConstantReader reader, List<T> values) => reader.isNull
@@ -91,3 +112,6 @@ T _enumValueForDartObject<T>(
     items.singleWhere(
       (v) => source.getField(name(v)) != null,
     );
+
+bool _parseBool(ConstantReader reader) =>
+    reader.isNull ? null : reader.boolValue;

--- a/functional_widget/lib/src/utils.dart
+++ b/functional_widget/lib/src/utils.dart
@@ -27,9 +27,9 @@ FunctionalWidget parseBuilderOptions(BuilderOptions options) {
       _parseRemoveLeadingUnderscore(options.config['removeLeadingUnderscore']);
 
   return FunctionalWidget(
-      widgetType: widgetType,
-      debugFillProperties: debugFillProperties,
-      equality: equality,
+    widgetType: widgetType,
+    debugFillProperties: debugFillProperties,
+    equality: equality,
     removeLeadingUnderscore: removeLeadingUnderscore,
   );
 }
@@ -42,8 +42,11 @@ bool _parseDebugFillProperties(dynamic value) {
   if (value is bool) {
     return value;
   }
-  throw ArgumentError.value(value, 'debugFillProperties',
-      'Invalid value. Potential values are `true` or `false`');
+  throw ArgumentError.value(
+    value,
+    'debugFillProperties',
+    'Invalid value. Potential values are `true` or `false`',
+  );
 }
 
 FunctionalWidgetEquality _parseEquality(dynamic value) {
@@ -94,12 +97,12 @@ bool _parseRemoveLeadingUnderscore(dynamic value) {
 
 FunctionalWidget parseFunctionalWidetAnnotation(ConstantReader reader) {
   return FunctionalWidget(
-      widgetType:
-          _parseEnum(reader.read('widgetType'), FunctionalWidgetType.values),
-      equality:
-          _parseEnum(reader.read('equality'), FunctionalWidgetEquality.values),
-      removeLeadingUnderscore:
-          _parseBool(reader.read('removeLeadingUnderscore')));
+    widgetType:
+        _parseEnum(reader.read('widgetType'), FunctionalWidgetType.values),
+    equality:
+        _parseEnum(reader.read('equality'), FunctionalWidgetEquality.values),
+    removeLeadingUnderscore: _parseBool(reader.read('removeLeadingUnderscore')),
+  );
 }
 
 T _parseEnum<T>(ConstantReader reader, List<T> values) => reader.isNull

--- a/functional_widget/lib/src/utils.dart
+++ b/functional_widget/lib/src/utils.dart
@@ -30,7 +30,8 @@ FunctionalWidget parseBuilderOptions(BuilderOptions options) {
       widgetType: widgetType,
       debugFillProperties: debugFillProperties,
       equality: equality,
-      removeLeadingUnderscore: removeLeadingUnderscore);
+    removeLeadingUnderscore: removeLeadingUnderscore,
+  );
 }
 
 bool _parseDebugFillProperties(dynamic value) {

--- a/functional_widget/pubspec.lock
+++ b/functional_widget/pubspec.lock
@@ -172,10 +172,10 @@ packages:
   functional_widget_annotation:
     dependency: "direct main"
     description:
-      path: "../functional_widget_annotation"
-      relative: true
-    source: path
-    version: "0.5.2"
+      name: functional_widget_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1"
   glob:
     dependency: transitive
     description:

--- a/functional_widget/pubspec.lock
+++ b/functional_widget/pubspec.lock
@@ -172,10 +172,10 @@ packages:
   functional_widget_annotation:
     dependency: "direct main"
     description:
-      name: functional_widget_annotation
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
+      path: "../functional_widget_annotation"
+      relative: true
+    source: path
+    version: "0.5.2"
   glob:
     dependency: transitive
     description:

--- a/functional_widget/pubspec.lock
+++ b/functional_widget/pubspec.lock
@@ -172,9 +172,9 @@ packages:
   functional_widget_annotation:
     dependency: "direct main"
     description:
-      name: functional_widget_annotation
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../functional_widget_annotation"
+      relative: true
+    source: path
     version: "0.5.1"
   glob:
     dependency: transitive

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -9,10 +9,6 @@ environment:
 
 dependencies:
     functional_widget_annotation: ^0.5.1
-<<<<<<< HEAD
-=======
-        #path: ../functional_widget_annotation
->>>>>>> 5e581f5... - remove path from yaml
     source_gen: ^0.9.4+1
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'
@@ -29,3 +25,7 @@ dev_dependencies:
     test_coverage: ^0.2.0
     code_gen_tester:
         path: ../code_gen_tester
+
+dependency_overrides:
+    functional_widget_annotation:
+        path: ../functional_widget_annotation

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -8,7 +8,8 @@ environment:
     sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-    functional_widget_annotation: ^0.5.1
+    functional_widget_annotation: #^0.5.1
+        path: ../functional_widget_annotation
     source_gen: ^0.9.4+1
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
     sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-    functional_widget_annotation: ^0.5.2
+    functional_widget_annotation: ^0.5.1
     source_gen: ^0.9.4+1
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -9,6 +9,10 @@ environment:
 
 dependencies:
     functional_widget_annotation: ^0.5.1
+<<<<<<< HEAD
+=======
+        #path: ../functional_widget_annotation
+>>>>>>> 5e581f5... - remove path from yaml
     source_gen: ^0.9.4+1
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
     sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-    functional_widget_annotation: ^0.5.0
+    functional_widget_annotation: ^0.5.2
     source_gen: ^0.9.4+1
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'

--- a/functional_widget/pubspec.yaml
+++ b/functional_widget/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
     sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
-    functional_widget_annotation: #^0.5.1
-        path: ../functional_widget_annotation
+    functional_widget_annotation: ^0.5.1
     source_gen: ^0.9.4+1
     build_config: '>=0.3.1+4 <1.0.0'
     code_builder: '>=3.2.0 <4.0.0'

--- a/functional_widget/test/src/success.dart
+++ b/functional_widget/test/src/success.dart
@@ -117,3 +117,11 @@ typedef _GenericFunction2 = T Function<T>(T foo);
 
 @widget
 Widget genericFunction2(_GenericFunction2 foo) => Container();
+
+@widget
+// ignore: unused_element
+Widget _withUnderscore() => Container();
+
+@FunctionalWidget(removeLeadingUnderscore: true)
+// ignore: unused_element
+Widget _withUnderscoreRemoved() => Container();

--- a/functional_widget/test/success_test.dart
+++ b/functional_widget/test/success_test.dart
@@ -230,6 +230,27 @@ class GenericExtends<T extends Container> extends StatelessWidget {
 '''));
     });
 
+    test('with underscore', () async {
+      await _expect('_withUnderscore', completion('''
+class _WithUnderscore extends StatelessWidget {
+  const _WithUnderscore({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _withUnderscore();
+}
+'''));
+    });
+    test('with underscore removed', () async {
+      await _expect('_withUnderscoreRemoved', completion('''
+class WithUnderscoreRemoved extends StatelessWidget {
+  const WithUnderscoreRemoved({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _withUnderscoreRemoved();
+}
+'''));
+    });
+
     group('functions', () {
       test('typedef', () async {
         await _expect('typedefFunction', completion('''

--- a/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -84,7 +84,7 @@ class FunctionalWidget {
   /// Defines if the generated widget should emit diagnostics informations.
   final bool debugFillProperties;
 
-  /// If true the leading underscore of the function is removed. This way,
+  /// If `true` the leading underscore of the function is removed. This way,
   /// a private function can be used to create a public widget class. If the
   /// function does not have a leading underscore, this option is ignored.
   ///

--- a/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -65,10 +65,10 @@ enum FunctionalWidgetEquality {
 
 /// Decorates a function to customize the generated class
 class FunctionalWidget {
-  const FunctionalWidget(
-      {this.widgetType,
-      this.equality,
-      this.debugFillProperties,
+  const FunctionalWidget({
+    this.widgetType,
+    this.equality,
+    this.debugFillProperties,
     this.removeLeadingUnderscore,
   });
 

--- a/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -69,7 +69,8 @@ class FunctionalWidget {
       {this.widgetType,
       this.equality,
       this.debugFillProperties,
-      this.removeLeadingUnderscore});
+    this.removeLeadingUnderscore,
+  });
 
   /// Configures which types of widget is generated.
   ///

--- a/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -65,11 +65,11 @@ enum FunctionalWidgetEquality {
 
 /// Decorates a function to customize the generated class
 class FunctionalWidget {
-  const FunctionalWidget({
-    this.widgetType,
-    this.equality,
-    this.debugFillProperties,
-  });
+  const FunctionalWidget(
+      {this.widgetType,
+      this.equality,
+      this.debugFillProperties,
+      this.removeLeadingUnderscore});
 
   /// Configures which types of widget is generated.
   ///
@@ -83,6 +83,13 @@ class FunctionalWidget {
 
   /// Defines if the generated widget should emit diagnostics informations.
   final bool debugFillProperties;
+
+  /// If true the leading underscore of the function is removed. This way,
+  /// a private function can be used to create a public widget class. If the
+  /// function does not have a leading underscore, this option is ignored.
+  ///
+  /// For example, the function `_foo` would generate class `Foo`.
+  final bool removeLeadingUnderscore;
 }
 
 /// A decorator for functions to generate a `Widget`.

--- a/functional_widget_annotation/pubspec.yaml
+++ b/functional_widget_annotation/pubspec.yaml
@@ -2,7 +2,7 @@ name: functional_widget_annotation
 description: Annotations for function_widget_generator used to generate widget classes from a function
 author: Remi Rousselet <darky12s@gmail.com>
 homepage: https://github.com/rrousselGit/functional_widget/tree/master/functional_widget_annotation
-version: 0.5.2
+version: 0.5.1
 
 environment:
     sdk: '>=2.1.0 <3.0.0'

--- a/functional_widget_annotation/pubspec.yaml
+++ b/functional_widget_annotation/pubspec.yaml
@@ -2,7 +2,7 @@ name: functional_widget_annotation
 description: Annotations for function_widget_generator used to generate widget classes from a function
 author: Remi Rousselet <darky12s@gmail.com>
 homepage: https://github.com/rrousselGit/functional_widget/tree/master/functional_widget_annotation
-version: 0.5.1
+version: 0.5.2
 
 environment:
     sdk: '>=2.1.0 <3.0.0'


### PR DESCRIPTION
Adds an option `removeLeadingUnderscore` to `FunctionalWidget`:

```
  /// If `true` the leading underscore of the function is removed. This way,
  /// a private function can be used to create a public widget class. If the
  /// function does not have a leading underscore, this option is ignored.
  ///
  /// For example, the function `_foo` would generate class `Foo`.
  final bool removeLeadingUnderscore;
```