### PR TITLE
Update `source_gen` and `build_runner`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,4 +42,4 @@ jobs:
         run: melos exec -- "flutter analyze"
 
       - name: Run tests
-        run: melos exec --scope="functional_widget" -- "dart --no-sound-null-safety test"
+        run: melos exec --scope="functional_widget" -- "dart test"

--- a/packages/code_gen_tester/lib/src/annotation.dart
+++ b/packages/code_gen_tester/lib/src/annotation.dart
@@ -4,13 +4,13 @@
 
 class ShouldThrow {
   final String errorMessage;
-  final String todo;
+  final String? todo;
   const ShouldThrow(this.errorMessage, [this.todo]);
 }
 
 class ShouldGenerate {
   final String expectedOutput;
-  final String expectedWrappedOutput;
+  final String? expectedWrappedOutput;
   final bool contains;
   final List<String> expectedLogItems;
   final bool checked;

--- a/packages/code_gen_tester/lib/src/tester.dart
+++ b/packages/code_gen_tester/lib/src/tester.dart
@@ -10,8 +10,8 @@ Future<void> expectGenerate(
   SourceGenTester tester,
   Generator generator,
   Matcher matcher, {
-  BuildStep buildStep,
-  String reason,
+  BuildStep? buildStep,
+  String? reason,
   dynamic skip,
 }) async {
   await expectLater(
@@ -27,8 +27,8 @@ Future<void> expectGenerateNamed(
   String name,
   GeneratorForAnnotation generator,
   Matcher matcher, {
-  BuildStep buildStep,
-  String reason,
+  BuildStep? buildStep,
+  String? reason,
   dynamic skip,
 }) async {
   await expectLater(
@@ -51,9 +51,9 @@ abstract class SourceGenTester {
     return _SourceGenTesterImpl(libraryReader);
   }
 
-  Future<String> generateFor(Generator generator, [BuildStep buildStep]);
+  Future<String> generateFor(Generator generator, [BuildStep? buildStep]);
   Future<String> generateForName(GeneratorForAnnotation generator, String name,
-      [BuildStep buildStep]);
+      [BuildStep? buildStep]);
 }
 
 class _SourceGenTesterImpl implements SourceGenTester {
@@ -63,7 +63,8 @@ class _SourceGenTesterImpl implements SourceGenTester {
   _SourceGenTesterImpl(this.library);
 
   @override
-  Future<String> generateFor(Generator generator, [BuildStep buildStep]) async {
+  Future<String> generateFor(Generator generator,
+      [BuildStep? buildStep]) async {
     final generated = await generator.generate(library, buildStep);
     final output = formatter.format(generated);
     printOnFailure('''
@@ -77,7 +78,7 @@ $output
 
   @override
   Future<String> generateForName(GeneratorForAnnotation generator, String name,
-      [BuildStep buildStep]) async {
+      [BuildStep? buildStep]) async {
     final e = library
         .annotatedWith(generator.typeChecker)
         .firstWhere((e) => e.element.name == name);

--- a/packages/code_gen_tester/lib/src/tester.dart
+++ b/packages/code_gen_tester/lib/src/tester.dart
@@ -71,7 +71,7 @@ class _SourceGenTesterImpl implements SourceGenTester {
       [BuildStep? buildStep]) async {
     final generated =
         await generator.generate(library, buildStep ?? _BuildStepImpl());
-    final output = formatter.format(generated ?? '');
+    final output = formatter.format(generated);
     printOnFailure('''
 Generator ${generator.runtimeType} generated:
 ```

--- a/packages/code_gen_tester/lib/src/tester.dart
+++ b/packages/code_gen_tester/lib/src/tester.dart
@@ -1,8 +1,12 @@
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:code_gen_tester/src/analysis_utils.dart';
+import 'package:crypto/crypto.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:glob/glob.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
@@ -65,8 +69,9 @@ class _SourceGenTesterImpl implements SourceGenTester {
   @override
   Future<String> generateFor(Generator generator,
       [BuildStep? buildStep]) async {
-    final generated = await generator.generate(library, buildStep);
-    final output = formatter.format(generated);
+    final generated =
+        await generator.generate(library, buildStep ?? _BuildStepImpl());
+    final output = formatter.format(generated ?? '');
     printOnFailure('''
 Generator ${generator.runtimeType} generated:
 ```
@@ -85,7 +90,7 @@ $output
     final dynamic generated = await generator.generateForAnnotatedElement(
       e.element,
       e.annotation,
-      buildStep,
+      buildStep ?? _BuildStepImpl(),
     );
 
     final output = formatter.format(generated.toString());
@@ -107,4 +112,65 @@ Matcher throwsInvalidGenerationSourceError([dynamic messageMatcher]) {
     c = c.having((e) => e.message, 'message', messageMatcher);
   }
   return throwsA(c);
+}
+
+class _BuildStepImpl implements BuildStep {
+  @override
+  AssetId get inputId => throw UnimplementedError();
+
+  @override
+  Future<LibraryElement> get inputLibrary => throw UnimplementedError();
+
+  @override
+  Resolver get resolver => throw UnimplementedError();
+
+  @override
+  Future<bool> canRead(AssetId id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Digest> digest(AssetId id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<T> fetchResource<T>(Resource<T> resource) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<AssetId> findAssets(Glob glob) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<int>> readAsBytes(AssetId id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<String> readAsString(AssetId id, {Encoding encoding = utf8}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void reportUnusedAssets(Iterable<AssetId> ids) {}
+
+  @override
+  T trackStage<T>(String label, T Function() action,
+      {bool isExternal = false}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> writeAsBytes(AssetId id, FutureOr<List<int>> bytes) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> writeAsString(AssetId id, FutureOr<String> contents,
+      {Encoding encoding = utf8}) {
+    throw UnimplementedError();
+  }
 }

--- a/packages/code_gen_tester/lib/src/tester.dart
+++ b/packages/code_gen_tester/lib/src/tester.dart
@@ -67,11 +67,13 @@ class _SourceGenTesterImpl implements SourceGenTester {
   _SourceGenTesterImpl(this.library);
 
   @override
-  Future<String> generateFor(Generator generator,
-      [BuildStep? buildStep]) async {
+  Future<String> generateFor(
+    Generator generator, [
+    BuildStep? buildStep,
+  ]) async {
     final generated =
         await generator.generate(library, buildStep ?? _BuildStepImpl());
-    final output = formatter.format(generated);
+    final output = formatter.format(generated!);
     printOnFailure('''
 Generator ${generator.runtimeType} generated:
 ```

--- a/packages/code_gen_tester/pubspec.yaml
+++ b/packages/code_gen_tester/pubspec.yaml
@@ -2,16 +2,16 @@ name: code_gen_tester
 version: 0.0.1
 
 environment:
-  sdk: ^2.5.0
+  sdk: ^2.12.0
 
 dependencies:
   test: ^1.15.4
   dart_style: ^1.3.6
   pedantic: ^1.9.0
-  build_runner: ^1.10.3
-  build_test: ^1.0.0
+  build_runner: ^1.12.1
+  build_test: ^2.0.0
   analyzer: ^1.0.0
-  build: ">=0.12.6 <2.0.0"
+  build: ">=2.0.0 <3.0.0"
   build_config: ">=0.4.2 <1.0.0"
   meta: ">=1.2.0 <2.0.0"
   functional_widget_annotation: ^0.9.0
@@ -19,8 +19,6 @@ dependencies:
   code_builder: ^3.2.1
 
 dependency_overrides:
+  build: ^2.0.0
   functional_widget_annotation:
     path: ../functional_widget_annotation
-
-dev_dependencies:
-  mockito: ^4.1.1

--- a/packages/code_gen_tester/pubspec.yaml
+++ b/packages/code_gen_tester/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   build_runner: ^1.12.1
   build_test: ^2.0.0
   analyzer: ^1.0.0
-  build: ">=2.0.0 <3.0.0"
+  build: ^2.0.0
   build_config: ">=0.4.2 <1.0.0"
-  meta: ">=1.2.0 <2.0.0"
+  meta: ^1.2.0
   functional_widget_annotation: ^0.9.0
   source_gen: ^1.0.0
   code_builder: ^3.2.1
@@ -21,4 +21,3 @@ dependencies:
 dependency_overrides:
   functional_widget_annotation:
     path: ../functional_widget_annotation
-

--- a/packages/code_gen_tester/pubspec.yaml
+++ b/packages/code_gen_tester/pubspec.yaml
@@ -16,8 +16,11 @@ dependencies:
   meta: ^1.2.0
   functional_widget_annotation: ^0.9.0
   source_gen: ^1.0.0
-  code_builder: ^3.2.1
+  code_builder: ^4.0.0
 
 dependency_overrides:
   functional_widget_annotation:
     path: ../functional_widget_annotation
+  code_builder:
+    git:
+      url: https://github.com/dart-lang/code_builder/

--- a/packages/code_gen_tester/pubspec.yaml
+++ b/packages/code_gen_tester/pubspec.yaml
@@ -15,13 +15,10 @@ dependencies:
   build_config: ">=0.4.2 <1.0.0"
   meta: ">=1.2.0 <2.0.0"
   functional_widget_annotation: ^0.9.0
-  source_gen: ^0.9.5
+  source_gen: ^1.0.0
   code_builder: ^3.2.1
 
 dependency_overrides:
   functional_widget_annotation:
     path: ../functional_widget_annotation
-  source_gen:
-    git:
-      url: https://github.com/dart-lang/source_gen.git
-      path: source_gen
+

--- a/packages/code_gen_tester/pubspec.yaml
+++ b/packages/code_gen_tester/pubspec.yaml
@@ -8,19 +8,12 @@ dependencies:
   test: ^1.15.4
   dart_style: ^2.0.0
   pedantic: ^1.9.0
-  build_runner: ^1.12.1
+  build_runner: ^2.0.0
   build_test: ^2.0.0
   analyzer: ^1.0.0
   build: ^2.0.0
-  build_config: ">=0.4.2 <1.0.0"
+  build_config: ^1.0.0
   meta: ^1.2.0
   functional_widget_annotation: ^0.9.0
   source_gen: ^1.0.0
   code_builder: ^4.0.0
-
-dependency_overrides:
-  functional_widget_annotation:
-    path: ../functional_widget_annotation
-  code_builder:
-    git:
-      url: https://github.com/dart-lang/code_builder/

--- a/packages/code_gen_tester/pubspec.yaml
+++ b/packages/code_gen_tester/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 
 dependencies:
   test: ^1.15.4
-  dart_style: ^1.3.6
+  dart_style: ^2.0.0
   pedantic: ^1.9.0
   build_runner: ^1.12.1
   build_test: ^2.0.0
@@ -19,6 +19,9 @@ dependencies:
   code_builder: ^3.2.1
 
 dependency_overrides:
-  build: ^2.0.0
   functional_widget_annotation:
     path: ../functional_widget_annotation
+  source_gen:
+    git:
+      url: https://github.com/dart-lang/source_gen.git
+      path: source_gen

--- a/packages/functional_widget/CHANGELOG.md
+++ b/packages/functional_widget/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+1
+
+Ugraded dependencies to latest
+
 ## 0.9.0
 
 Migrated to null-safety (thanks to @tim-smart)

--- a/packages/functional_widget/example/pubspec.yaml
+++ b/packages/functional_widget/example/pubspec.yaml
@@ -16,3 +16,6 @@ dev_dependencies:
 dependency_overrides:
   functional_widget_annotation:
     path: ../../functional_widget_annotation
+  code_builder:
+    git:
+      url: https://github.com/dart-lang/code_builder/

--- a/packages/functional_widget/example/pubspec.yaml
+++ b/packages/functional_widget/example/pubspec.yaml
@@ -11,11 +11,8 @@ dependencies:
 dev_dependencies:
   functional_widget:
     path: ..
-  build_runner: ^1.9.0
+  build_runner: ^2.0.0
 
 dependency_overrides:
   functional_widget_annotation:
     path: ../../functional_widget_annotation
-  code_builder:
-    git:
-      url: https://github.com/dart-lang/code_builder/

--- a/packages/functional_widget/lib/function_to_widget_class.dart
+++ b/packages/functional_widget/lib/function_to_widget_class.dart
@@ -37,7 +37,11 @@ class FunctionalWidgetGenerator
         );
 
   final FunctionalWidget _defaultOptions;
-  final _emitter = DartEmitter(Allocator.none, false, true);
+  final _emitter = DartEmitter(
+    allocator: Allocator.none,
+    orderDirectives: false,
+    useNullSafetySyntax: true,
+  );
 
   @override
   String generateForAnnotatedElement(
@@ -105,7 +109,7 @@ class FunctionalWidgetGenerator
           ..methods.add(_createBuildMethod(
               functionElement.displayName, positional, named, functionElement));
         if (functionElement.documentationComment != null) {
-          b.docs.add(functionElement.documentationComment);
+          b.docs.add(functionElement.documentationComment!);
         }
         if (annotation.debugFillProperties ??
             _defaultOptions.debugFillProperties ??
@@ -175,7 +179,7 @@ class FunctionalWidgetGenerator
 
   Code _parameterToDiagnostic(Parameter parameter, ParameterElement element) {
     String? propertyType;
-    switch (parameter.type.symbol) {
+    switch (parameter.type!.symbol) {
       case 'int':
         propertyType = 'IntProperty';
         break;

--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart' as element_type;
@@ -95,8 +96,8 @@ FunctionType _functionTypedElementToFunctionType(
 }
 
 String tryParseDynamicType(ParameterElement element) {
-  final parsedLibrary =
-      element.session?.getParsedLibraryByElement(element.library!);
+  final parsedLibrary = element.session
+      ?.getParsedLibraryByElement2(element.library!) as ParsedLibraryResult?;
   final node = parsedLibrary?.getElementDeclaration(element)?.node;
   final parameter = node is DefaultFormalParameter ? node.parameter : node;
   if (parameter is SimpleFormalParameter && parameter.type != null) {

--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -39,7 +39,7 @@ Parameter _parseParameter(ParameterElement parameter) {
     (b) => b
       ..name = parameter.name
       ..defaultTo = parameter.defaultValueCode != null
-          ? Code(parameter.defaultValueCode)
+          ? Code(parameter.defaultValueCode!)
           : null
       ..docs.add(parameter.documentationComment ?? '')
       ..annotations.addAll(parameter.metadata.map((meta) {
@@ -82,15 +82,15 @@ FunctionType _functionTypedElementToFunctionType(
       ..requiredParameters.addAll(element.parameters
           .where((p) => p.isNotOptional)
           .map(_parseParameter)
-          .map((p) => p.type))
+          .map((p) => p.type!))
       ..namedParameters.addEntries(element.parameters
           .where((p) => p.isNamed)
           .map(_parseParameter)
-          .map((p) => MapEntry(p.name, p.type)))
+          .map((p) => MapEntry(p.name, p.type!)))
       ..optionalParameters.addAll(element.parameters
           .where((p) => p.isOptionalPositional)
           .map(_parseParameter)
-          .map((p) => p.type));
+          .map((p) => p.type!));
   });
 }
 

--- a/packages/functional_widget/lib/src/utils.dart
+++ b/packages/functional_widget/lib/src/utils.dart
@@ -2,13 +2,13 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:build/build.dart';
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'package:source_gen/source_gen.dart';
+import 'package:collection/collection.dart';
 
 const _kKnownOptionsName = ['widgetType', 'equality', 'debugFillProperties'];
 
 FunctionalWidget parseBuilderOptions(BuilderOptions options) {
-  final unknownOption = options.config?.keys.firstWhere(
-      (key) => !_kKnownOptionsName.contains(key),
-      orElse: () => null);
+  final unknownOption = options.config.keys
+      .firstWhereOrNull((key) => !_kKnownOptionsName.contains(key));
 
   if (unknownOption != null) {
     throw ArgumentError(

--- a/packages/functional_widget/pubspec.yaml
+++ b/packages/functional_widget/pubspec.yaml
@@ -9,9 +9,9 @@ environment:
 
 dependencies:
   analyzer: ^1.1.0
-  build: ">=2.0.0 <3.0.0"
+  build: ^2.0.0
   build_config: ">=0.4.2 <1.0.0"
-  meta: ">=1.2.0 <2.0.0"
+  meta: ^1.2.0
   functional_widget_annotation: ^0.9.0
   source_gen: ^1.0.0
   code_builder: ^3.6.0

--- a/packages/functional_widget/pubspec.yaml
+++ b/packages/functional_widget/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: ^1.1.0
-  build: ">=0.12.6 <2.0.0"
+  build: ">=2.0.0 <3.0.0"
   build_config: ">=0.4.2 <1.0.0"
   meta: ">=1.2.0 <2.0.0"
   functional_widget_annotation: ^0.9.0
@@ -19,12 +19,16 @@ dependencies:
 dependency_overrides:
   functional_widget_annotation:
     path: ../functional_widget_annotation
+  source_gen:
+    git:
+      url: https://github.com/dart-lang/source_gen.git
+      path: source_gen
 
 dev_dependencies:
   test: ^1.15.4
   mockito: ^4.1.1
-  dart_style: ^1.3.6
+  dart_style: ^2.0.0
   pedantic: ^1.9.0
-  build_runner: ^1.10.3
+  build_runner: ^1.12.1
   code_gen_tester:
     path: ../code_gen_tester

--- a/packages/functional_widget/pubspec.yaml
+++ b/packages/functional_widget/pubspec.yaml
@@ -2,7 +2,7 @@ name: functional_widget
 description: A code generator that generates widget classes from their implementation as a function.
 author: Remi Rousselet <darky12s@gmail.com>
 homepage: https://github.com/rrousselGit/functional_widget/tree/master/functional_widget
-version: 0.9.0
+version: 0.9.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,24 +10,17 @@ environment:
 dependencies:
   analyzer: ^1.1.0
   build: ^2.0.0
-  build_config: ">=0.4.2 <1.0.0"
+  build_config: ^1.0.0
   meta: ^1.2.0
   functional_widget_annotation: ^0.9.0
   source_gen: ^1.0.0
   code_builder: ^4.0.0
-
-dependency_overrides:
-  functional_widget_annotation:
-    path: ../functional_widget_annotation
-  code_builder:
-    git:
-      url: https://github.com/dart-lang/code_builder/
 
 dev_dependencies:
   test: ^1.15.4
   mockito: ^4.1.1
   dart_style: ^2.0.0
   pedantic: ^1.9.0
-  build_runner: ^1.12.1
+  build_runner: ^2.0.0
   code_gen_tester:
     path: ../code_gen_tester

--- a/packages/functional_widget/pubspec.yaml
+++ b/packages/functional_widget/pubspec.yaml
@@ -13,16 +13,12 @@ dependencies:
   build_config: ">=0.4.2 <1.0.0"
   meta: ">=1.2.0 <2.0.0"
   functional_widget_annotation: ^0.9.0
-  source_gen: ^0.9.5
+  source_gen: ^1.0.0
   code_builder: ^3.6.0
 
 dependency_overrides:
   functional_widget_annotation:
     path: ../functional_widget_annotation
-  source_gen:
-    git:
-      url: https://github.com/dart-lang/source_gen.git
-      path: source_gen
 
 dev_dependencies:
   test: ^1.15.4

--- a/packages/functional_widget/pubspec.yaml
+++ b/packages/functional_widget/pubspec.yaml
@@ -14,11 +14,14 @@ dependencies:
   meta: ^1.2.0
   functional_widget_annotation: ^0.9.0
   source_gen: ^1.0.0
-  code_builder: ^3.6.0
+  code_builder: ^4.0.0
 
 dependency_overrides:
   functional_widget_annotation:
     path: ../functional_widget_annotation
+  code_builder:
+    git:
+      url: https://github.com/dart-lang/code_builder/
 
 dev_dependencies:
   test: ^1.15.4

--- a/packages/functional_widget_annotation/example/pubspec.yaml
+++ b/packages/functional_widget_annotation/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  build_runner: ^1.9.0
+  build_runner: ^2.0.0
 
 dependency_overrides:
   functional_widget_annotation:


### PR DESCRIPTION
Can remove the git dependency when https://github.com/dart-lang/source_gen publishes their null safety work.