### PR TITLE
Fix inconsistent analysis exception

### DIFF
--- a/packages/code_gen_tester/lib/src/tester.dart
+++ b/packages/code_gen_tester/lib/src/tester.dart
@@ -1,7 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:_fe_analyzer_shared/src/base/syntactic_entity.dart';
+import 'package:_fe_analyzer_shared/src/scanner/token.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/generated/java_engine.dart';
 import 'package:build/build.dart';
 import 'package:code_gen_tester/src/analysis_utils.dart';
 import 'package:crypto/crypto.dart';
@@ -124,7 +128,7 @@ class _BuildStepImpl implements BuildStep {
   Future<LibraryElement> get inputLibrary => throw UnimplementedError();
 
   @override
-  Resolver get resolver => throw UnimplementedError();
+  Resolver get resolver => _ResolverImpl();
 
   @override
   Future<bool> canRead(AssetId id) {
@@ -175,4 +179,106 @@ class _BuildStepImpl implements BuildStep {
       {Encoding encoding = utf8}) {
     throw UnimplementedError();
   }
+}
+
+class _ResolverImpl implements Resolver {
+  @override
+  Future<AssetId> assetIdForElement(Element element) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AstNode?> astNodeFor(Element element, {bool resolve = false}) {
+    return Future.value(_AstNodeImpl());
+  }
+
+  @override
+  Future<CompilationUnit> compilationUnitFor(AssetId assetId,
+      {bool allowSyntaxErrors = false}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<LibraryElement?> findLibraryByName(String libraryName) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> isLibrary(AssetId assetId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<LibraryElement> get libraries => throw UnimplementedError();
+
+  @override
+  Future<LibraryElement> libraryFor(AssetId assetId,
+      {bool allowSyntaxErrors = false}) {
+    throw UnimplementedError();
+  }
+}
+
+class _AstNodeImpl implements AstNode {
+  @override
+  E? accept<E>(AstVisitor<E> visitor) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Token get beginToken => throw UnimplementedError();
+
+  @override
+  Iterable<SyntacticEntity> get childEntities => throw UnimplementedError();
+
+  @override
+  int get end => throw UnimplementedError();
+
+  @override
+  Token get endToken => throw UnimplementedError();
+
+  @override
+  Token? findPrevious(Token target) {
+    throw UnimplementedError();
+  }
+
+  @override
+  E? getProperty<E>(String name) {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool get isSynthetic => throw UnimplementedError();
+
+  @override
+  int get length => throw UnimplementedError();
+
+  @override
+  int get offset => throw UnimplementedError();
+
+  @override
+  AstNode? get parent => throw UnimplementedError();
+
+  @override
+  AstNode get root => throw UnimplementedError();
+
+  @override
+  void setProperty(String name, Object? value) {}
+
+  @override
+  E? thisOrAncestorMatching<E extends AstNode>(Predicate<AstNode> predicate) {
+    throw UnimplementedError();
+  }
+
+  @override
+  E? thisOrAncestorOfType<E extends AstNode>() {
+    throw UnimplementedError();
+  }
+
+  @override
+  String toSource() {
+    throw UnimplementedError();
+  }
+
+  @override
+  void visitChildren(AstVisitor visitor) {}
 }

--- a/packages/functional_widget/lib/function_to_widget_class.dart
+++ b/packages/functional_widget/lib/function_to_widget_class.dart
@@ -163,7 +163,7 @@ class FunctionalWidgetGenerator
       return null;
     }
 
-    final _diagnosticProperties = await Future.wait(userFields.map((f) async =>
+    final _diagnosticProperties = await Future.wait(userFields.map((f) =>
         _parameterToDiagnostic(
             f, elements.firstWhere((e) => e.name == f.name), buildStep)));
 

--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/dart/analysis/results.dart';
+import 'package:build/build.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart' as element_type;
@@ -8,9 +8,13 @@ import 'package:analyzer/dart/ast/ast.dart';
 class FunctionParameters {
   FunctionParameters._(this._parameters);
 
-  factory FunctionParameters.parseFunctionElement(FunctionElement element) {
-    return FunctionParameters._(
-        element.parameters.map(_parseParameter).toList());
+  static Future<FunctionParameters> parseFunctionElement(
+      FunctionElement element, BuildStep buildStep) async {
+    final parsedParameters =
+        element.parameters.map((p) => _parseParameter(p, buildStep));
+    final elementParams = await Future.wait(parsedParameters);
+
+    return FunctionParameters._(elementParams.toList());
   }
 
   final List<Parameter> _parameters;
@@ -35,7 +39,10 @@ bool _isKey(Parameter param) => param.type?.symbol == 'Key';
 bool _isContext(Parameter param) =>
     param.type?.symbol == 'BuildContext' || param.type?.symbol == 'HookContext';
 
-Parameter _parseParameter(ParameterElement parameter) {
+Future<Parameter> _parseParameter(
+    ParameterElement parameter, BuildStep buildStep) async {
+  final _type = await _parameterToReference(parameter, buildStep);
+
   return Parameter(
     (b) => b
       ..name = parameter.name
@@ -49,56 +56,88 @@ Parameter _parseParameter(ParameterElement parameter) {
       }))
       ..named = parameter.isNamed
       ..required = parameter.isRequiredNamed
-      ..type = _parameterToReference(parameter),
+      ..type = _type,
   );
 }
 
-Reference _parameterToReference(ParameterElement element) {
+Future<Reference> _parameterToReference(
+    ParameterElement element, BuildStep buildStep) async {
   if (element.type.isDynamic) {
-    return refer(tryParseDynamicType(element));
+    return refer(await tryParseDynamicType(element, buildStep));
   }
+  final typeToReference = await _typeToReference(element.type, buildStep);
 
-  return _typeToReference(element.type);
+  return typeToReference;
 }
 
-Reference _typeToReference(element_type.DartType type) {
+Future<Reference> _typeToReference(
+    element_type.DartType type, BuildStep buildStep) async {
   if (type is element_type.FunctionType) {
     // final functionTyped = type.element as FunctionTypedElement;
-    final t = _functionTypedElementToFunctionType(type);
+    final t = await _functionTypedElementToFunctionType(type, buildStep);
     return t.type;
   }
   final displayName = type.getDisplayString(withNullability: true);
   return refer(displayName);
 }
 
-FunctionType _functionTypedElementToFunctionType(
-  element_type.FunctionType element,
-) {
-  return FunctionType((b) {
-    b
-      ..returnType = _typeToReference(element.returnType)
-      ..types.addAll(element.typeFormals.map((f) => _typeToReference(
-          f.instantiate(nullabilitySuffix: NullabilitySuffix.none))))
+Future<FunctionType> _functionTypedElementToFunctionType(
+    element_type.FunctionType element, BuildStep buildStep) async {
+  final _returnType = await _typeToReference(element.returnType, buildStep);
+  final _parameterTypes = await Future.wait(element.typeFormals.map(
+    (f) => _typeToReference(
+        f.instantiate(nullabilitySuffix: NullabilitySuffix.none), buildStep),
+  ));
+  final _requiredParameterReferences =
+      await _mapOrListParameterReferences<Reference>(
+    element.parameters,
+    (p) => p.isNotOptional,
+    (p) => p.type!,
+    buildStep,
+  );
+  final _namedParameterEntries =
+      await _mapOrListParameterReferences<MapEntry<String, Reference>>(
+    element.parameters,
+    (p) => p.isNamed,
+    (p) => MapEntry(p.name, p.type!),
+    buildStep,
+  );
+  final _optionalParameterReferences =
+      await _mapOrListParameterReferences<Reference>(
+    element.parameters,
+    (p) => p.isOptionalPositional,
+    (p) => p.type!,
+    buildStep,
+  );
+
+  return FunctionType(
+    (b) => b
+      ..returnType = _returnType
+      ..types.addAll(_parameterTypes)
       ..isNullable = element.nullabilitySuffix == NullabilitySuffix.question
-      ..requiredParameters.addAll(element.parameters
-          .where((p) => p.isNotOptional)
-          .map(_parseParameter)
-          .map((p) => p.type!))
-      ..namedParameters.addEntries(element.parameters
-          .where((p) => p.isNamed)
-          .map(_parseParameter)
-          .map((p) => MapEntry(p.name, p.type!)))
-      ..optionalParameters.addAll(element.parameters
-          .where((p) => p.isOptionalPositional)
-          .map(_parseParameter)
-          .map((p) => p.type!));
-  });
+      ..requiredParameters.addAll(_requiredParameterReferences)
+      ..namedParameters.addEntries(_namedParameterEntries)
+      ..optionalParameters.addAll(_optionalParameterReferences),
+  );
 }
 
-String tryParseDynamicType(ParameterElement element) {
-  final parsedLibrary = element.session
-      ?.getParsedLibraryByElement2(element.library!) as ParsedLibraryResult?;
-  final node = parsedLibrary?.getElementDeclaration(element)?.node;
+Future<Iterable<T>> _mapOrListParameterReferences<T>(
+  List<ParameterElement> params,
+  bool Function(ParameterElement param) filterFunction,
+  T Function(Parameter p) mapOrListfunction,
+  BuildStep buildStep,
+) async {
+  final parsedParams = await Future.wait(
+    params.where(filterFunction).map((p) => _parseParameter(p, buildStep)),
+  );
+  final mapOrListParamaterReferences = parsedParams.map<T>(mapOrListfunction);
+
+  return mapOrListParamaterReferences;
+}
+
+Future<String> tryParseDynamicType(
+    ParameterElement element, BuildStep buildStep) async {
+  final node = await buildStep.resolver.astNodeFor(element);
   final parameter = node is DefaultFormalParameter ? node.parameter : node;
   if (parameter is SimpleFormalParameter && parameter.type != null) {
     return parameter.type!.beginToken.toString();

--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -1,9 +1,9 @@
-import 'package:build/build.dart';
+import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart' as element_type;
+import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
-import 'package:analyzer/dart/ast/ast.dart';
 
 class FunctionParameters {
   FunctionParameters._(this._parameters);

--- a/packages/functional_widget/lib/src/utils.dart
+++ b/packages/functional_widget/lib/src/utils.dart
@@ -1,8 +1,8 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:build/build.dart';
+import 'package:collection/collection.dart';
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:collection/collection.dart';
 
 const _kKnownOptionsName = ['widgetType', 'equality', 'debugFillProperties'];
 

--- a/packages/functional_widget/test/parse_options_test.dart
+++ b/packages/functional_widget/test/parse_options_test.dart
@@ -1,7 +1,7 @@
 import 'package:build/build.dart';
+import 'package:functional_widget/src/utils.dart';
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'package:test/test.dart';
-import 'package:functional_widget/src/utils.dart';
 
 void main() {
   group('parseOptions', () {


### PR DESCRIPTION
My team has been experiencing InconsistentAnalysisException errors on the latest functional_widget version while upgrading our codebase to null safety.

This PR utilizes the resolver.astNodeForFunction (added here: https://github.com/dart-lang/build/pull/2947/files) to circumvent the error.