### PR TITLE
fix: homepage url for packages

### DIFF
--- a/packages/functional_widget/pubspec.yaml
+++ b/packages/functional_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: functional_widget
 description: A code generator that generates widget classes from their implementation as a function.
 author: Remi Rousselet <darky12s@gmail.com>
-homepage: https://github.com/rrousselGit/functional_widget/tree/master/functional_widget
+homepage: https://github.com/rrousselGit/functional_widget/tree/master/packages/functional_widget
 version: 0.9.0+2
 
 environment:

--- a/packages/functional_widget_annotation/pubspec.yaml
+++ b/packages/functional_widget_annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: functional_widget_annotation
 description: Annotations for function_widget_generator used to generate widget classes from a function
 author: Remi Rousselet <darky12s@gmail.com>
-homepage: https://github.com/rrousselGit/functional_widget/tree/master/functional_widget_annotation
+homepage: https://github.com/rrousselGit/functional_widget/tree/master/packages/functional_widget_annotation
 version: 0.9.0
 
 environment:

--- a/packages/functional_widget_annotation/pubspec.yaml
+++ b/packages/functional_widget_annotation/pubspec.yaml
@@ -1,6 +1,5 @@
 name: functional_widget_annotation
 description: Annotations for function_widget_generator used to generate widget classes from a function
-author: Remi Rousselet <darky12s@gmail.com>
 homepage: https://github.com/rrousselGit/functional_widget/tree/master/packages/functional_widget_annotation
 version: 0.9.0
 


### PR DESCRIPTION
pub.dev - score

Homepage URL doesn't exist.
At the time of the analysis https://github.com/rrousselGit/functional_widget/tree/master/functional_widget was unreachable.