### PR TITLE
Two new properties: public and name @ FunctionalWidget

### DIFF
--- a/packages/functional_widget/README.md
+++ b/packages/functional_widget/README.md
@@ -295,8 +295,31 @@ Widget foo(BuildContext context, int value, { int value2 }) {
 Foo(42, value2: 24);
 ```
 
-### Export widgets for private functions
+### Private vs public widgets
 
-By default, generated code for private functions will also be private.
-In order to export those functions, you can use two alternative decorators
-```@sWidget``` for StatelessWidget and ```@hWidget``` for HookWidgets.
+In order to allow for private function definitions but exported widgets, all
+decorated widget functions with a single underscore will generate an exported widget.
+
+```dart
+@swidget
+Widget _foo(BuildContext context, int value, { int value2 }) {
+  return Text('$value $value2');
+}
+
+// USAGE
+
+Foo(42, value2: 24);
+```
+
+In order to keep generated widget private, do use two underscores:
+
+```dart
+@swidget
+Widget __foo(BuildContext context, int value, { int value2 }) {
+  return Text('$value $value2');
+}
+
+// USAGE
+
+_Foo(42, value2: 24);
+```

--- a/packages/functional_widget/README.md
+++ b/packages/functional_widget/README.md
@@ -217,20 +217,6 @@ There are a few ways to do so:
   Widget example(int foo, String bar) => Container();
   ```
 
-- With parameters on the `@FunctionalWidget` decorator that will export the generated widget for private functions:
-
-  ```dart
-  @FunctionalWidget(public: true)
-  Widget _privateButExportedExample(int foo, String bar) => Container();
-  ```
-
-- With parameters on the `@FunctionalWidget` decorator that will replace the name with a custom name:
-
-  ```dart
-  @FunctionalWidget(name: "CustomName")
-  Widget willReceiveCustomNameExample(int foo, String bar) => Container();
-  ```
-
 - With the shorthand `@hwidget` decorator:
 
   ```dart

--- a/packages/functional_widget/README.md
+++ b/packages/functional_widget/README.md
@@ -217,6 +217,20 @@ There are a few ways to do so:
   Widget example(int foo, String bar) => Container();
   ```
 
+- With parameters on the `@FunctionalWidget` decorator that will export the generated widget for private functions:
+
+  ```dart
+  @FunctionalWidget(public: true)
+  Widget _privateButExportedExample(int foo, String bar) => Container();
+  ```
+
+- With parameters on the `@FunctionalWidget` decorator that will replace the name with a custom name:
+
+  ```dart
+  @FunctionalWidget(name: "CustomName")
+  Widget willReceiveCustomNameExample(int foo, String bar) => Container();
+  ```
+
 - With the shorthand `@hwidget` decorator:
 
   ```dart
@@ -280,3 +294,9 @@ Widget foo(BuildContext context, int value, { int value2 }) {
 
 Foo(42, value2: 24);
 ```
+
+### Export widgets for private functions
+
+By default, generated code for private functions will also be private.
+In order to export those functions, you can use two alternative decorators
+```@sWidget``` for StatelessWidget and ```@hWidget``` for HookWidgets.

--- a/packages/functional_widget/example/lib/main.dart
+++ b/packages/functional_widget/example/lib/main.dart
@@ -25,13 +25,13 @@ Widget _example(BuildContext ctx) {
   return Container();
 }
 
-@hWidget
-Widget _privateHook(BuildContext ctx) {
+@hwidget
+Widget __privateHook(BuildContext ctx) {
   return Container();
 }
 
-@sWidget
-Widget _privateStatelessWidget(BuildContext ctx) {
+@swidget
+Widget __privateStatelessWidget(BuildContext ctx) {
   return Container();
 }
 

--- a/packages/functional_widget/example/lib/main.dart
+++ b/packages/functional_widget/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 
 part 'main.g.dart';
 
@@ -16,6 +17,21 @@ Widget example(
   String bar, {
   ValueChanged<bool>? onChanged,
 }) {
+  return Container();
+}
+
+@FunctionalWidget(name: 'Example2')
+Widget _example(BuildContext ctx) {
+  return Container();
+}
+
+@hWidget
+Widget _privateHook(BuildContext ctx) {
+  return Container();
+}
+
+@sWidget
+Widget _privateStatelessWidget(BuildContext ctx) {
   return Container();
 }
 

--- a/packages/functional_widget/example/lib/main.dart
+++ b/packages/functional_widget/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 
 part 'main.g.dart';
 
@@ -22,11 +21,6 @@ Widget example(
 
 @FunctionalWidget(name: 'Example2')
 Widget _example(BuildContext ctx) {
-  return Container();
-}
-
-@hwidget
-Widget __privateHook(BuildContext ctx) {
   return Container();
 }
 

--- a/packages/functional_widget/example/lib/main.g.dart
+++ b/packages/functional_widget/example/lib/main.g.dart
@@ -50,16 +50,16 @@ class Example2 extends StatelessWidget {
   Widget build(BuildContext _context) => _example(_context);
 }
 
-class PrivateHook extends HookWidget {
-  const PrivateHook({Key? key}) : super(key: key);
+class _PrivateHook extends HookWidget {
+  const _PrivateHook({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext _context) => _privateHook(_context);
+  Widget build(BuildContext _context) => __privateHook(_context);
 }
 
-class PrivateStatelessWidget extends StatelessWidget {
-  const PrivateStatelessWidget({Key? key}) : super(key: key);
+class _PrivateStatelessWidget extends StatelessWidget {
+  const _PrivateStatelessWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext _context) => _privateStatelessWidget(_context);
+  Widget build(BuildContext _context) => __privateStatelessWidget(_context);
 }

--- a/packages/functional_widget/example/lib/main.g.dart
+++ b/packages/functional_widget/example/lib/main.g.dart
@@ -50,13 +50,6 @@ class Example2 extends StatelessWidget {
   Widget build(BuildContext _context) => _example(_context);
 }
 
-class _PrivateHook extends HookWidget {
-  const _PrivateHook({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext _context) => __privateHook(_context);
-}
-
 class _PrivateStatelessWidget extends StatelessWidget {
   const _PrivateStatelessWidget({Key? key}) : super(key: key);
 

--- a/packages/functional_widget/example/lib/main.g.dart
+++ b/packages/functional_widget/example/lib/main.g.dart
@@ -38,6 +38,28 @@ class Example extends StatelessWidget {
     super.debugFillProperties(properties);
     properties.add(IntProperty('foo', foo));
     properties.add(StringProperty('bar', bar));
-    properties.add(ObjectFlagProperty<dynamic>.has('onChanged', onChanged));
+    properties
+        .add(DiagnosticsProperty<void Function(bool)?>('onChanged', onChanged));
   }
+}
+
+class Example2 extends StatelessWidget {
+  const Example2({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _example(_context);
+}
+
+class PrivateHook extends HookWidget {
+  const PrivateHook({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _privateHook(_context);
+}
+
+class PrivateStatelessWidget extends StatelessWidget {
+  const PrivateStatelessWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _privateStatelessWidget(_context);
 }

--- a/packages/functional_widget/example/pubspec.yaml
+++ b/packages/functional_widget/example/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_hooks: ^0.18.0
   functional_widget_annotation:
 
 dev_dependencies:

--- a/packages/functional_widget/example/pubspec.yaml
+++ b/packages/functional_widget/example/pubspec.yaml
@@ -6,7 +6,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_hooks: ^0.18.0
   functional_widget_annotation:
 
 dev_dependencies:

--- a/packages/functional_widget/lib/function_to_widget_class.dart
+++ b/packages/functional_widget/lib/function_to_widget_class.dart
@@ -54,8 +54,8 @@ class FunctionalWidgetGenerator
     }
     var out = element.name ?? '';
 
-    // as discussed, let's remove first underscore in order to allow for private fns
-    // to become public (https://github.com/rrousselGit/functional_widget/pull/97#discussion_r720210353)
+    // We remove the fist _ such that _widget becomes Widget and __widget
+    // becomes _Widget, giving some control over the privacy of the generated class
     if (out.isNotEmpty && out[0] == '_') {
       out = out.substring(1);
     }
@@ -106,7 +106,7 @@ class FunctionalWidgetGenerator
 
     if (className == function.name) {
       throw InvalidGenerationSourceError(
-        'The function name must start with a lowercase character. Alternatively, the function can be private',
+        'The function name must start with a lowercase character.',
         element: function,
       );
     }

--- a/packages/functional_widget/lib/src/utils.dart
+++ b/packages/functional_widget/lib/src/utils.dart
@@ -70,17 +70,6 @@ String? parseFunctionalWidgetName(ConstantReader reader) {
   throw ArgumentError('Unknown type for name: must be string or null');
 }
 
-bool? parseFunctionalWidgetPublic(ConstantReader reader) {
-  final val = reader.read('public');
-  if (val.isNull) {
-    return null;
-  }
-  if (val.isBool) {
-    return val.boolValue;
-  }
-  throw ArgumentError('Unknown type for public: must be bool or null');
-}
-
 T? _parseEnum<T>(ConstantReader reader, List<T> values) => reader.isNull
     ? null
     : _enumValueForDartObject(

--- a/packages/functional_widget/lib/src/utils.dart
+++ b/packages/functional_widget/lib/src/utils.dart
@@ -59,6 +59,28 @@ FunctionalWidget parseFunctionalWidgetAnnotation(ConstantReader reader) {
   );
 }
 
+String? parseFunctionalWidgetName(ConstantReader reader) {
+  final val = reader.read('name');
+  if (val.isNull) {
+    return null;
+  }
+  if (val.isString) {
+    return val.stringValue;
+  }
+  throw ArgumentError('Unknown type for name: must be string or null');
+}
+
+bool? parseFunctionalWidgetPublic(ConstantReader reader) {
+  final val = reader.read('public');
+  if (val.isNull) {
+    return null;
+  }
+  if (val.isBool) {
+    return val.boolValue;
+  }
+  throw ArgumentError('Unknown type for public: must be bool or null');
+}
+
 T? _parseEnum<T>(ConstantReader reader, List<T> values) => reader.isNull
     ? null
     : _enumValueForDartObject(

--- a/packages/functional_widget/test/decorator_test.dart
+++ b/packages/functional_widget/test/decorator_test.dart
@@ -8,7 +8,7 @@ void main() {
   final tester = SourceGenTester.fromPath('test/src/success.dart');
 
   group('decorators', () {
-    test('swidget generate statelesswidget even if default value is hook',
+    test('swidget generates stateless widget even if default value is hook',
         () async {
       final _generator = FunctionalWidgetGenerator(
           const FunctionalWidget(widgetType: FunctionalWidgetType.hook));
@@ -25,20 +25,34 @@ class SXWidget extends StatelessWidget {
 '''));
     });
 
-    test(
-        'swidget generate statelesswidget even if default value is hook and private',
-        () async {
+    test('swidget generates private widget from double-private fn', () async {
       final _generator = FunctionalWidgetGenerator(
           const FunctionalWidget(widgetType: FunctionalWidgetType.hook));
       final _expect = (String name, Matcher matcher) async =>
           expectGenerateNamed(await tester, name, _generator, matcher);
 
-      await _expect('_privateSWidget', completion('''
+      await _expect('__privateSWidget', completion('''
 class _PrivateSWidget extends StatelessWidget {
   const _PrivateSWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext _context) => _privateSWidget();
+  Widget build(BuildContext _context) => __privateSWidget();
+}
+'''));
+    });
+
+    test('swidget generates public stateless widget from private fn', () async {
+      final _generator = FunctionalWidgetGenerator(
+          const FunctionalWidget(widgetType: FunctionalWidgetType.hook));
+      final _expect = (String name, Matcher matcher) async =>
+          expectGenerateNamed(await tester, name, _generator, matcher);
+
+      await _expect('_publicSWidget', completion('''
+class PublicSWidget extends StatelessWidget {
+  const PublicSWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _publicSWidget();
 }
 '''));
     });
@@ -60,57 +74,40 @@ class HXWidget extends HookWidget {
 '''));
     });
 
-    test(
-        'hwidget generate hookwidget even if default value is stateless and private',
+    test('hwidget generates public hook widget from private fn', () async {
+      final _generator = FunctionalWidgetGenerator(
+          const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
+      final _expect = (String name, Matcher matcher) async =>
+          expectGenerateNamed(await tester, name, _generator, matcher);
+
+      await _expect('_publicHWidget', completion('''
+class PublicHWidget extends HookWidget {
+  const PublicHWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _publicHWidget();
+}
+'''));
+    });
+
+    test('hwidget generates private hook widget from double-private fn',
         () async {
       final _generator = FunctionalWidgetGenerator(
           const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
       final _expect = (String name, Matcher matcher) async =>
           expectGenerateNamed(await tester, name, _generator, matcher);
 
-      await _expect('_privateHWidget', completion('''
+      await _expect('__privateHWidget', completion('''
 class _PrivateHWidget extends HookWidget {
   const _PrivateHWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext _context) => _privateHWidget();
+  Widget build(BuildContext _context) => __privateHWidget();
 }
 '''));
     });
 
     group('exported private widgets', () {
-      test('sWidget exports private member', () async {
-        final _generator = FunctionalWidgetGenerator(
-            const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
-        final _expect = (String name, Matcher matcher) async =>
-            expectGenerateNamed(await tester, name, _generator, matcher);
-
-        await _expect('_privateButPublicSWidget', completion('''
-class PrivateButPublicSWidget extends StatelessWidget {
-  const PrivateButPublicSWidget({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext _context) => _privateButPublicSWidget();
-}
-'''));
-      });
-
-      test('hWidget exports private member', () async {
-        final _generator = FunctionalWidgetGenerator(
-            const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
-        final _expect = (String name, Matcher matcher) async =>
-            expectGenerateNamed(await tester, name, _generator, matcher);
-
-        await _expect('_privateButPublicHWidget', completion('''
-class PrivateButPublicHWidget extends HookWidget {
-  const PrivateButPublicHWidget({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext _context) => _privateButPublicHWidget();
-}
-'''));
-      });
-
       test('generate hook if conf is hook', () async {
         var _generator = FunctionalWidgetGenerator(
             const FunctionalWidget(widgetType: FunctionalWidgetType.hook));

--- a/packages/functional_widget/test/decorator_test.dart
+++ b/packages/functional_widget/test/decorator_test.dart
@@ -15,12 +15,30 @@ void main() {
       final _expect = (String name, Matcher matcher) async =>
           expectGenerateNamed(await tester, name, _generator, matcher);
 
-      await _expect('sWidget', completion('''
-class SWidget extends StatelessWidget {
-  const SWidget({Key? key}) : super(key: key);
+      await _expect('sXWidget', completion('''
+class SXWidget extends StatelessWidget {
+  const SXWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext _context) => sWidget();
+  Widget build(BuildContext _context) => sXWidget();
+}
+'''));
+    });
+
+    test(
+        'swidget generate statelesswidget even if default value is hook and private',
+        () async {
+      final _generator = FunctionalWidgetGenerator(
+          const FunctionalWidget(widgetType: FunctionalWidgetType.hook));
+      final _expect = (String name, Matcher matcher) async =>
+          expectGenerateNamed(await tester, name, _generator, matcher);
+
+      await _expect('_privateSWidget', completion('''
+class _PrivateSWidget extends StatelessWidget {
+  const _PrivateSWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _privateSWidget();
 }
 '''));
     });
@@ -32,15 +50,84 @@ class SWidget extends StatelessWidget {
       final _expect = (String name, Matcher matcher) async =>
           expectGenerateNamed(await tester, name, _generator, matcher);
 
-      await _expect('hWidget', completion('''
-class HWidget extends HookWidget {
-  const HWidget({Key? key}) : super(key: key);
+      await _expect('hXWidget', completion('''
+class HXWidget extends HookWidget {
+  const HXWidget({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext _context) => hWidget();
+  Widget build(BuildContext _context) => hXWidget();
 }
 '''));
     });
+
+    test(
+        'hwidget generate hookwidget even if default value is stateless and private',
+        () async {
+      final _generator = FunctionalWidgetGenerator(
+          const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
+      final _expect = (String name, Matcher matcher) async =>
+          expectGenerateNamed(await tester, name, _generator, matcher);
+
+      await _expect('_privateHWidget', completion('''
+class _PrivateHWidget extends HookWidget {
+  const _PrivateHWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _privateHWidget();
+}
+'''));
+    });
+
+    group('exported private widgets', () {
+      test('sWidget exports private member', () async {
+        final _generator = FunctionalWidgetGenerator(
+            const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
+        final _expect = (String name, Matcher matcher) async =>
+            expectGenerateNamed(await tester, name, _generator, matcher);
+
+        await _expect('_privateButPublicSWidget', completion('''
+class PrivateButPublicSWidget extends StatelessWidget {
+  const PrivateButPublicSWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _privateButPublicSWidget();
+}
+'''));
+      });
+
+      test('hWidget exports private member', () async {
+        final _generator = FunctionalWidgetGenerator(
+            const FunctionalWidget(widgetType: FunctionalWidgetType.stateless));
+        final _expect = (String name, Matcher matcher) async =>
+            expectGenerateNamed(await tester, name, _generator, matcher);
+
+        await _expect('_privateButPublicHWidget', completion('''
+class PrivateButPublicHWidget extends HookWidget {
+  const PrivateButPublicHWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => _privateButPublicHWidget();
+}
+'''));
+      });
+
+      test('generate hook if conf is hook', () async {
+        var _generator = FunctionalWidgetGenerator(
+            const FunctionalWidget(widgetType: FunctionalWidgetType.hook));
+        final _expect = (String name, Matcher matcher) async =>
+            expectGenerateNamed(await tester, name, _generator, matcher);
+
+        await _expect('adaptiveWidget', completion('''
+class AdaptiveWidget extends StatelessWidget {
+  const AdaptiveWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => adaptiveWidget();
+}
+'''));
+      });
+    });
+
     group('@swidget', () {
       test('generate stateless if conf is stateless', () async {
         var _generator = FunctionalWidgetGenerator(

--- a/packages/functional_widget/test/src/success.dart
+++ b/packages/functional_widget/test/src/success.dart
@@ -7,19 +7,19 @@ import 'fake_flutter.dart';
 Widget sXWidget() => Container();
 
 @swidget
-Widget _privateSWidget() => Container();
+Widget _publicSWidget() => Container();
 
-@sWidget
-Widget _privateButPublicSWidget() => Container();
+@swidget
+Widget __privateSWidget() => Container();
 
 @hwidget
 Widget hXWidget() => Container();
 
 @hwidget
-Widget _privateHWidget() => Container();
+Widget _publicHWidget() => Container();
 
-@hWidget
-Widget _privateButPublicHWidget() => Container();
+@hwidget
+Widget __privateHWidget() => Container();
 
 @swidget
 Widget adaptiveWidget() => Container();

--- a/packages/functional_widget/test/src/success.dart
+++ b/packages/functional_widget/test/src/success.dart
@@ -4,10 +4,22 @@ import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'fake_flutter.dart';
 
 @swidget
-Widget sWidget() => Container();
+Widget sXWidget() => Container();
+
+@swidget
+Widget _privateSWidget() => Container();
+
+@sWidget
+Widget _privateButPublicSWidget() => Container();
 
 @hwidget
-Widget hWidget() => Container();
+Widget hXWidget() => Container();
+
+@hwidget
+Widget _privateHWidget() => Container();
+
+@hWidget
+Widget _privateButPublicHWidget() => Container();
 
 @swidget
 Widget adaptiveWidget() => Container();

--- a/packages/functional_widget/test/src/success.dart
+++ b/packages/functional_widget/test/src/success.dart
@@ -142,3 +142,15 @@ typedef _GenericFunction4 = T? Function<T>(T? foo);
 
 @swidget
 Widget genericFunction4(_GenericFunction4? foo) => Container();
+
+@FunctionalWidget(
+  widgetType: FunctionalWidgetType.hook,
+  name: 'CustomHookWidget',
+)
+Widget hookWidgetWithCustomName(BuildContext ctx) => Container();
+
+@FunctionalWidget(
+  widgetType: FunctionalWidgetType.stateless,
+  name: 'CustomStatelessWidget',
+)
+Widget statelessWidgetWithCustomName(BuildContext ctx) => Container();

--- a/packages/functional_widget/test/src/success.dart
+++ b/packages/functional_widget/test/src/success.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: implicit_dynamic_parameter
+// ignore_for_file: implicit_dynamic_parameter, unused_element, private elements are used by the tests
 
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
 import 'fake_flutter.dart';

--- a/packages/functional_widget/test/success_test.dart
+++ b/packages/functional_widget/test/success_test.dart
@@ -388,5 +388,30 @@ class GenericFunction4 extends StatelessWidget {
 '''));
       });
     });
+
+    group('custom named widgets', () {
+      test('hook widget', () async {
+        await _expect('hookWidgetWithCustomName', completion('''
+class CustomHookWidget extends HookWidget {
+  const CustomHookWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => hookWidgetWithCustomName(_context);
+}
+'''));
+      });
+
+      test('stateless widget', () async {
+        await _expect('statelessWidgetWithCustomName', completion('''
+class CustomStatelessWidget extends StatelessWidget {
+  const CustomStatelessWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) =>
+      statelessWidgetWithCustomName(_context);
+}
+'''));
+      });
+    });
   });
 }

--- a/packages/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/packages/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -21,7 +21,6 @@ class FunctionalWidget {
     this.widgetType = FunctionalWidgetType.stateless,
     this.debugFillProperties,
     this.name,
-    this.public,
   });
 
   /// Configures which types of widget is generated.
@@ -34,9 +33,6 @@ class FunctionalWidget {
 
   /// Name specifies the widget's name
   final String? name;
-
-  /// Defines whether the widget is to be made public
-  final bool? public;
 }
 
 /// A decorator for functions to generate a `StatelessWidget`.
@@ -45,17 +41,6 @@ class FunctionalWidget {
 /// with an uppercase as first letter.
 const FunctionalWidget swidget = FunctionalWidget(
   widgetType: FunctionalWidgetType.stateless,
-);
-
-/// A decorator for functions to generate a `StatelessWidget`.
-///
-/// The name of the generated widget is the name of the decorated function,
-/// with an uppercase as first letter.
-/// In case provided function was private, the class name will result in an exposed
-/// class (e.g. _foo ==> Foo);
-const FunctionalWidget sWidget = FunctionalWidget(
-  widgetType: FunctionalWidgetType.stateless,
-  public: true,
 );
 
 /// A decorator for functions to generate a `HookWidget`.
@@ -71,18 +56,3 @@ const FunctionalWidget sWidget = FunctionalWidget(
 const FunctionalWidget hwidget = FunctionalWidget(
   widgetType: FunctionalWidgetType.hook,
 );
-
-/// A decorator for functions to generate a `HookWidget`.
-///
-/// `HookWidget` must be installed as a separate dependency:
-/// ```yaml
-/// dependencies:
-///   flutter_hooks: any
-/// ```
-///
-/// The name of the generated widget is the name of the decorated function,
-/// with an uppercase as first letter.
-/// In case provided function was private, the class name will result in an exposed
-/// class (e.g. _foo ==> Foo);
-const FunctionalWidget hWidget =
-    FunctionalWidget(widgetType: FunctionalWidgetType.hook, public: true);

--- a/packages/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/packages/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -20,6 +20,8 @@ class FunctionalWidget {
   const FunctionalWidget({
     this.widgetType = FunctionalWidgetType.stateless,
     this.debugFillProperties,
+    this.name,
+    this.public,
   });
 
   /// Configures which types of widget is generated.
@@ -29,6 +31,12 @@ class FunctionalWidget {
 
   /// Defines if the generated widget should emit diagnostics informations.
   final bool? debugFillProperties;
+
+  /// Name specifies the widget's name
+  final String? name;
+
+  /// Defines whether the widget is to be made public
+  final bool? public;
 }
 
 /// A decorator for functions to generate a `StatelessWidget`.
@@ -37,6 +45,17 @@ class FunctionalWidget {
 /// with an uppercase as first letter.
 const FunctionalWidget swidget = FunctionalWidget(
   widgetType: FunctionalWidgetType.stateless,
+);
+
+/// A decorator for functions to generate a `StatelessWidget`.
+///
+/// The name of the generated widget is the name of the decorated function,
+/// with an uppercase as first letter.
+/// In case provided function was private, the class name will result in an exposed
+/// class (e.g. _foo ==> Foo);
+const FunctionalWidget sWidget = FunctionalWidget(
+  widgetType: FunctionalWidgetType.stateless,
+  public: true,
 );
 
 /// A decorator for functions to generate a `HookWidget`.
@@ -52,3 +71,18 @@ const FunctionalWidget swidget = FunctionalWidget(
 const FunctionalWidget hwidget = FunctionalWidget(
   widgetType: FunctionalWidgetType.hook,
 );
+
+/// A decorator for functions to generate a `HookWidget`.
+///
+/// `HookWidget` must be installed as a separate dependency:
+/// ```yaml
+/// dependencies:
+///   flutter_hooks: any
+/// ```
+///
+/// The name of the generated widget is the name of the decorated function,
+/// with an uppercase as first letter.
+/// In case provided function was private, the class name will result in an exposed
+/// class (e.g. _foo ==> Foo);
+const FunctionalWidget hWidget =
+    FunctionalWidget(widgetType: FunctionalWidgetType.hook, public: true);

--- a/packages/functional_widget_annotation/lib/functional_widget_annotation.dart
+++ b/packages/functional_widget_annotation/lib/functional_widget_annotation.dart
@@ -31,7 +31,12 @@ class FunctionalWidget {
   /// Defines if the generated widget should emit diagnostics informations.
   final bool? debugFillProperties;
 
-  /// Name specifies the widget's name
+  /// Defines the name of the generated widget.
+  ///
+  /// By default, uses the function name, such that:
+  ///
+  /// - `Widget _myWidget(...)` generates `class MyWidget`
+  /// - `Widget __myWidget(...)` generates `class _MyWidget`
   final String? name;
 }
 


### PR DESCRIPTION
In order to allow for custom name, I added the property 'name' to the FunctionalWidget.

Furthermore, private functions were translated into a private widget which can now be exported by using the property 'name'.

For ease of use I also added two new decorators:

@ sWidget <<-- makes private stateless widgets public
@ hWidget <<-- makes private hook widgets public