### PR TITLE
Fix annotations with parameters

### DIFF
--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -90,8 +90,7 @@ Future<Parameter> _parseParameter(
           : null
       ..docs.add(parameter.documentationComment ?? '')
       ..annotations.addAll(parameter.metadata.map((meta) {
-        // ignore: invalid_use_of_visible_for_testing_member
-        return CodeExpression(Code(meta.element!.displayName));
+        return CodeExpression(Code(meta.toSource().replaceFirst('@', '')));
       }))
       ..named = parameter.isNamed
       ..required = parameter.isRequiredNamed

--- a/packages/functional_widget/test/src/success.dart
+++ b/packages/functional_widget/test/src/success.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: implicit_dynamic_parameter
 
 import 'package:functional_widget_annotation/functional_widget_annotation.dart';
+
 import 'fake_flutter.dart';
 
 @swidget
@@ -158,3 +159,21 @@ typedef _GenericFunction4 = T? Function<T>(T? foo);
 
 @swidget
 Widget genericFunction4(_GenericFunction4? foo) => Container();
+
+class TestAnnotation {
+  const TestAnnotation([this.argument = 'default']);
+
+  final String argument;
+}
+
+@swidget
+Widget annotation({@TestAnnotation() int foo = 42}) => Container();
+
+@swidget
+Widget annotationParameter({@TestAnnotation('Test') int foo = 42}) =>
+    Container();
+
+const testAnnotation = TestAnnotation('Another test');
+
+@swidget
+Widget annotationConstant({@testAnnotation int foo = 42}) => Container();

--- a/packages/functional_widget/test/success_test.dart
+++ b/packages/functional_widget/test/success_test.dart
@@ -515,5 +515,49 @@ class GenericFunction4 extends StatelessWidget {
 '''));
       });
     });
+
+    group('annotations', () {
+      test('annotation', () async {
+        await _expect('annotation', completion('''
+class Annotation extends StatelessWidget {
+  const Annotation({Key? key, @TestAnnotation() this.foo = 42})
+      : super(key: key);
+
+  final int foo;
+
+  @override
+  Widget build(BuildContext _context) => annotation(foo: foo);
+}
+'''));
+      });
+
+      test('annotationParameter', () async {
+        await _expect('annotationParameter', completion('''
+class AnnotationParameter extends StatelessWidget {
+  const AnnotationParameter({Key? key, @TestAnnotation('Test') this.foo = 42})
+      : super(key: key);
+
+  final int foo;
+
+  @override
+  Widget build(BuildContext _context) => annotationParameter(foo: foo);
+}
+'''));
+      });
+
+      test('annotationConstant', () async {
+        await _expect('annotationConstant', completion('''
+class AnnotationConstant extends StatelessWidget {
+  const AnnotationConstant({Key? key, @testAnnotation this.foo = 42})
+      : super(key: key);
+
+  final int foo;
+
+  @override
+  Widget build(BuildContext _context) => annotationConstant(foo: foo);
+}
+'''));
+      });
+    });
   });
 }


### PR DESCRIPTION
I'm using this library together with [`auto_route`](https://pub.dev/packages/auto_route) which expects an annotation on e.g. query parameters:
```dart
@FunctionalWidget()
Widget myPage(
  BuildContext context, {
  @QueryParam('tab') int? initialTabIndex,
}) => Container();
```

Previously, the constructor for the generated widget was missing the brackets and therefore also parameters:

```dart
const MyPage({Key? key, @QueryParam this.initialTabIndex})
```

This PR fixed that behavior and copies the whole annotation source from the function widget to the constructor:

```dart
const MyPage({Key? key, @QueryParam('tab') this.initialTabIndex})
```

I've also added some tests for this case.
