### PR TITLE
Add Theme.of to predefined paramteres

### DIFF
--- a/packages/functional_widget/lib/function_to_widget_class.dart
+++ b/packages/functional_widget/lib/function_to_widget_class.dart
@@ -191,12 +191,18 @@ class FunctionalWidgetGenerator
   List<Expression> _computeBuildPositionalParametersExpression(
       FunctionParameters parameters) {
     return <Expression>[
-      ...parameters.nonUserDefinedRenamed
-          .map((p) => CodeExpression(Code(p.name))),
+      ...parameters.nonUserDefinedRenamed.map(_computeParameterExpression),
       ...parameters.userDefined
           .where((p) => !p.named)
           .map((p) => CodeExpression(Code(p.name)))
     ];
+  }
+
+  CodeExpression _computeParameterExpression(Parameter paramater) {
+    if (paramater.type?.symbol == 'ThemeData') {
+      return const CodeExpression(Code('Theme.of(_context)'));
+    }
+    return CodeExpression(Code(paramater.name));
   }
 
   Future<Method?> _overrideDebugFillProperties(List<Parameter> userFields,

--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -14,12 +14,14 @@ class FunctionParameters {
     'Key?',
     'BuildContext',
     'WidgetRef',
+    'ThemeData',
   ];
   static const nonUserDefinedNames = {
     'Key': 'key!',
     'Key?': 'key',
     'BuildContext': '_context',
     'WidgetRef': '_ref',
+    'ThemeData': 'theme',
   };
 
   static Future<FunctionParameters> parseFunctionElement(

--- a/packages/functional_widget/test/src/fake_flutter.dart
+++ b/packages/functional_widget/test/src/fake_flutter.dart
@@ -7,3 +7,5 @@ class BuildContext {}
 class Key {}
 
 class WidgetRef {}
+
+class ThemeData {}

--- a/packages/functional_widget/test/src/success.dart
+++ b/packages/functional_widget/test/src/success.dart
@@ -61,10 +61,34 @@ Widget withContextThenContext(BuildContext context, BuildContext context2) =>
     Container();
 
 @swidget
+Widget withThemeData(ThemeData theme) => Container();
+
+@swidget
 Widget withKeyThenContext(Key key, BuildContext context) => Container();
 
 @swidget
+Widget withContextThenThemeData(BuildContext context, ThemeData theme) =>
+    Container();
+
+@swidget
+Widget withThemeDataThenContext(ThemeData theme, BuildContext context) =>
+    Container();
+
+@swidget
+Widget withKeyThenThemeData(Key key, ThemeData theme) => Container();
+
+@swidget
+Widget withKeyThenContextThenThemeData(
+        Key key, BuildContext context, ThemeData theme) =>
+    Container();
+
+@swidget
 Widget withKeyThenContextThenOneArg(Key key, BuildContext context, int foo) =>
+    Container();
+
+@swidget
+Widget withKeyThenContextThenThemeDataThenOneArg(
+        Key key, BuildContext context, ThemeData theme, int foo) =>
     Container();
 
 @swidget
@@ -75,6 +99,9 @@ Widget whateverThenContext(int foo, BuildContext bar) => Container();
 
 @swidget
 Widget whateverThenKey(int foo, Key bar) => Container();
+
+@swidget
+Widget whateverThenThemeData(int foo, ThemeData bar) => Container();
 
 /// Hello
 /// World

--- a/packages/functional_widget/test/success_test.dart
+++ b/packages/functional_widget/test/success_test.dart
@@ -122,6 +122,17 @@ class WithContextThenContext extends StatelessWidget {
 '''));
     });
 
+    test('theme data', () async {
+      await _expect('withThemeData', completion('''
+class WithThemeData extends StatelessWidget {
+  const WithThemeData({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => withThemeData(Theme.of(_context));
+}
+'''));
+    });
+
     test('key then context', () async {
       await _expect('withKeyThenContext', completion('''
 class WithKeyThenContext extends StatelessWidget {
@@ -131,6 +142,63 @@ class WithKeyThenContext extends StatelessWidget {
   Widget build(BuildContext _context) => withKeyThenContext(
         key!,
         _context,
+      );
+}
+'''));
+    });
+
+    test('context then theme data', () async {
+      await _expect('withContextThenThemeData', completion('''
+class WithContextThenThemeData extends StatelessWidget {
+  const WithContextThenThemeData({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => withContextThenThemeData(
+        _context,
+        Theme.of(_context),
+      );
+}
+'''));
+    });
+
+    test('theme data then context', () async {
+      await _expect('withThemeDataThenContext', completion('''
+class WithThemeDataThenContext extends StatelessWidget {
+  const WithThemeDataThenContext({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => withThemeDataThenContext(
+        Theme.of(_context),
+        _context,
+      );
+}
+'''));
+    });
+
+    test('key then theme data', () async {
+      await _expect('withKeyThenThemeData', completion('''
+class WithKeyThenThemeData extends StatelessWidget {
+  const WithKeyThenThemeData({required Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => withKeyThenThemeData(
+        key!,
+        Theme.of(_context),
+      );
+}
+'''));
+    });
+
+    test('key then context then theme data', () async {
+      await _expect('withKeyThenContextThenThemeData', completion('''
+class WithKeyThenContextThenThemeData extends StatelessWidget {
+  const WithKeyThenContextThenThemeData({required Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext _context) => withKeyThenContextThenThemeData(
+        key!,
+        _context,
+        Theme.of(_context),
       );
 }
 '''));
@@ -150,6 +218,28 @@ class WithKeyThenContextThenOneArg extends StatelessWidget {
   Widget build(BuildContext _context) => withKeyThenContextThenOneArg(
         key!,
         _context,
+        foo,
+      );
+}
+'''));
+    });
+
+    test('key then context then theme data then arg', () async {
+      await _expect('withKeyThenContextThenThemeDataThenOneArg', completion('''
+class WithKeyThenContextThenThemeDataThenOneArg extends StatelessWidget {
+  const WithKeyThenContextThenThemeDataThenOneArg(
+    this.foo, {
+    required Key key,
+  }) : super(key: key);
+
+  final int foo;
+
+  @override
+  Widget build(BuildContext _context) =>
+      withKeyThenContextThenThemeDataThenOneArg(
+        key!,
+        _context,
+        Theme.of(_context),
         foo,
       );
 }
@@ -212,6 +302,28 @@ class WhateverThenKey extends StatelessWidget {
 
   @override
   Widget build(BuildContext _context) => whateverThenKey(
+        foo,
+        bar,
+      );
+}
+'''));
+    });
+
+    test('whatever then theme data', () async {
+      await _expect('whateverThenThemeData', completion('''
+class WhateverThenThemeData extends StatelessWidget {
+  const WhateverThenThemeData(
+    this.foo,
+    this.bar, {
+    Key? key,
+  }) : super(key: key);
+
+  final int foo;
+
+  final ThemeData bar;
+
+  @override
+  Widget build(BuildContext _context) => whateverThenThemeData(
         foo,
         bar,
       );


### PR DESCRIPTION
I added `ThemeData` as predefined parameter that solves a common use case which makes it unnecessary to define `Theme.of(context)` in the function. 
This is not backward compatible for developers who already defined ThemeData in parameter list.