### PR TITLE
Fix build workflow errors

### DIFF
--- a/packages/functional_widget/lib/function_to_widget_class.dart
+++ b/packages/functional_widget/lib/function_to_widget_class.dart
@@ -109,8 +109,7 @@ class FunctionalWidgetGenerator
     if (function.isAsynchronous ||
         function.isExternal ||
         function.isGenerator ||
-        function.returnType.getDisplayString(withNullability: true) !=
-            'Widget') {
+        function.returnType.getDisplayString() != 'Widget') {
       throw InvalidGenerationSourceError(
         'Invalid prototype. The function must be synchronous, top level, and return a Widget',
         element: function,
@@ -273,8 +272,7 @@ class FunctionalWidgetGenerator
   String? _tryParseClassToEnumDiagnostic(
       ParameterElement element, String? propertyType) {
     if (element.type.element is EnumElement) {
-      propertyType =
-          'EnumProperty<${element.type.getDisplayString(withNullability: true)}>';
+      propertyType = 'EnumProperty<${element.type.getDisplayString()}>';
     }
     return propertyType;
   }
@@ -317,7 +315,7 @@ class FunctionalWidgetGenerator
     List<TypeParameterElement> typeParameters,
   ) {
     return typeParameters.map((e) {
-      final displayName = e.bound?.getDisplayString(withNullability: true);
+      final displayName = e.bound?.getDisplayString();
       return displayName != null
           ? refer('${e.displayName} extends $displayName')
           : refer(e.displayName);

--- a/packages/functional_widget/lib/src/parameters.dart
+++ b/packages/functional_widget/lib/src/parameters.dart
@@ -116,7 +116,7 @@ Future<Reference> _typeToReference(
     final t = await _functionTypedElementToFunctionType(type, buildStep);
     return t.type;
   }
-  final displayName = type.getDisplayString(withNullability: true);
+  final displayName = type.getDisplayString();
   return refer(displayName);
 }
 


### PR DESCRIPTION
Remove specifying the `withNullability` flag to `true` because it already has a default value of `true`. The build workflow was failing because the `withNullability` flag is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified type display formatting by removing explicit nullability indicators.
	- Standardized type references for consistency without affecting public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->