### PR TITLE
Remove `pubspec_overrides.yaml` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage/
 *.iml
 .idea
 pubspec.lock
+pubspec_overrides.yaml

--- a/packages/functional_widget/pubspec_overrides.yaml
+++ b/packages/functional_widget/pubspec_overrides.yaml
@@ -1,3 +1,0 @@
-dependency_overrides:
-  functional_widget_annotation:
-    path: ../functional_widget_annotation


### PR DESCRIPTION
These files are automatically generated when running `melos bootstrap`

According to the official Melos [documentation](https://melos.invertase.dev/~501/getting-started#configure-the-workspace):

> Melos generates `pubspec_overrides.yaml` files to link local packages for development. Typically these files should be ignored by git. To ignore these files, add the following to your `.gitignore` file:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version control ignore settings.
	- Removed a local dependency override, reverting to the default dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->